### PR TITLE
Turn joystick init message into warning.

### DIFF
--- a/launch/joy.py
+++ b/launch/joy.py
@@ -9,6 +9,7 @@ def generate_launch_description():
       name='joy',
       namespace='l3xz',
       output='screen',
+      emulate_tty=True,
       parameters=[
         {'joy_dev_node': '/dev/input/js0'},
         {'joy_topic': 'joy'},

--- a/src/joystick/Node.cpp
+++ b/src/joystick/Node.cpp
@@ -74,7 +74,7 @@ void Node::joystickThreadFunc()
 {
   _joy_thread_active = true;
 
-  RCLCPP_INFO(get_logger(), "Please press [START] on your PS3 joystick.");
+  RCLCPP_WARN(get_logger(), "Please press [START] on your PS3 joystick.");
 
   while (_joy_thread_active)
   {


### PR DESCRIPTION
This is highlighted within the console and therefore better visible.