### PR TITLE
Fix: Using a poll before read allows for clean exit of node.

### DIFF
--- a/include/l3xz_joy/PS3/Joystick.h
+++ b/include/l3xz_joy/PS3/Joystick.h
@@ -35,7 +35,7 @@ public:
 
   ~Joystick();
 
-  JoystickEvent update();
+  std::optional<JoystickEvent> update();
 
 private:
   int _fd;

--- a/include/l3xz_joy/PS3/JoystickEvent.h
+++ b/include/l3xz_joy/PS3/JoystickEvent.h
@@ -34,8 +34,8 @@ public:
 
   uint32_t time;     /* event timestamp in milliseconds */
   int16_t  value;    /* value */
-  uint8_t  type;      /* event type */
-  uint8_t  number;    /* axis/button number */
+  uint8_t  type;     /* event type */
+  uint8_t  number;   /* axis/button number */
 
   inline bool isButton() const { return ((type & EVENT_BUTTON) == EVENT_BUTTON); }
   inline bool isAxis  () const { return ((type & EVENT_AXIS)   == EVENT_AXIS); }


### PR DESCRIPTION
Otherwise the thread is stuck at the blocking read() call during exit, if no new joystick command comes in.